### PR TITLE
Dev

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -78,21 +78,6 @@ jobs:
           else
             echo 'No Supabase images detected to cache'
           fi
-
-      # Pre-warm Playwright browsers cache for later jobs
-      - name: Determine Playwright version
-        id: playwright-version
-        run: echo version=$(node -e "console.log(require('playwright/package.json').version)") >> $GITHUB_OUTPUT
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright browsers (populate cache)
-        run: npx playwright install --with-deps
-
       - name: Start Supabase stack
         run: supabase start
       - name: Update Supabase Migrations

--- a/agentlog.md
+++ b/agentlog.md
@@ -1,3 +1,55 @@
+2025-10-07 11:55 — Scanner-Suche für Articles & Locations
+- Artikel- und Standorttabellen bekommen denselben Suchleisten-Scanner wie Equipments; Seiten-Header-Buttons entfernt.
+- Tabellen verstecken Asset-Tag mobil und zeigen ihn im Footer, Icon-Button sitzt neben der Suche.
+- Files: components/articleTable.tsx, components/locationTable.tsx, app/management/{articles,locations}/page.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-07 11:40 — Contact-Typ im mobilen Footer
+- Contacts-Tabelle zeigt jetzt den Contact Type unten rechts, passend zum globalen Footer-Layout.
+- Files: components/customerTable.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-07 11:30 — Artikel-Asset-Tag im mobilen Footer
+- Artikel-Tabelle blendet Asset-Tag mobil aus und zeigt ihn unten rechts analog zur Equipment-Liste.
+- Files: components/articleTable.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-07 11:20 — Global mobile ID footer
+- DataTable blendet die ID Spalte mobil automatisch aus und zeigt sie links im Footer; rechter Footer bleibt konfigurierbar.
+- Footer-Layout passt sich optionalem Right-Content an, Gruppenlayout nutzt Dreierspalten.
+- Files: components/data-table.tsx, components/equipmentTable.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-07 11:05 — Footer zeigt Inventardatum + kompakte Zeile
+- Mobile DataTable gruppiert die ersten drei Felder (ID, Artikel, Standort) in einer Zeile; Restfelder spannen die Breite.
+- Footer kombiniert jetzt „Im Lager seit …“ mit dem Asset-Tag als dezentes Label.
+- Files: components/data-table.tsx, components/equipmentTable.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-07 10:55 — Mobile Asset-Tag Footer
+- Asset-Tag Spalte in mobilen Karten ausgeblendet und als dezentes Footer-Label unten rechts platziert; DataTable bekam optionalen Mobile-Footer.
+- Equipment-Suche zeigt den Scan-Hinweis weiterhin über den Icon-Button.
+- Files: components/data-table.tsx, components/equipmentTable.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-07 10:35 — Pair mobile DataTable fields & add scanner icon
+- Gruppierte mobile Kartenwerte zu Zweier-Reihen (z.B. ID + Artikel) und platzierte den Asset-Tag-Scan als Icon neben dem Suchfeld.
+- Equipment-Seite gibt den Scanner-Handler nun an das Table weiter; alter Header-Button entfällt.
+- Files: components/data-table.tsx, components/equipmentTable.tsx, app/management/equipments/page.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-07 10:05 — Compact mobile cards for DataTable
+- Reduzierte Padding und stellte Label/Value in einem zweispaltigen Grid dar, damit mobile Karten deutlich weniger vertikalen Platz belegen.
+- Importierte React.Fragment für saubere Key-Nutzung.
+- Files: components/data-table.tsx
+- Verification: npm run test:tsc ✅
+
+2025-10-06 09:40 — Improve equipment table mobile layout
+- Ergänzte eine mobile Card-Ansicht im generischen DataTable, damit Tabellen auf <640px ohne Horizontal-Scroll funktionieren; Desktop behält die klassische Tabelle.
+- Markierte mobile Container mit `data-testid` und fügte Playwright-Regression für Equipment-Liste (mobile/desktop) hinzu.
+- Files: components/data-table.tsx, tests/e2e/equipment-list-responsive.loggedin.spec.ts
+- Verification: npm run test:tsc ✅, npx playwright test equipment-list-responsive.loggedin.spec.ts ⚠️ (fehlende Env: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY)
+
 2025-10-06 09:05 — Clean up header unused props after drawer removal
 - Entfernte ungenutzte Icon-Map & `items`-Prop aus dem Header, nachdem der MobileDrawer entfiel; ManagementShell-Aufruf aktualisiert
 - ESLint `no-unused-vars` Warnungen beseitigt, Typprüfung bleibt grün
@@ -1315,3 +1367,8 @@ Files: lib/tools/deleteCompany.ts, tests/vitest/delete-company.test.ts. Next: ru
   * Easier to understand what each placeholder will render
 - Files: template-preview.tsx, asset-tag-template-create-form.tsx
 - TypeScript compilation: ✅ PASSED
+2025-10-07: Mobile equipment page responsive layout overhaul; touched components/data-table.tsx, app/management/equipments/page.tsx.
+2025-10-07 — Mobile equipment table flush on phones
+- Entfernte den horizontalen Außenabstand der Equipment-Übersichtskarte auf kleinen Viewports über eine responsive Klassenkombination, Desktop bleibt unverändert mit Padding/Radien
+- Files: app/management/equipments/page.tsx
+- Verification: npm run test:tsc ✅

--- a/app/management/articles/page.tsx
+++ b/app/management/articles/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { QrScannerModal } from "@/components/camera/qr-scanner-modal";
 import { useQrScanner } from "@/components/camera/use-qr-scanner";
 import { createClient } from "@/lib/supabase/client";
-import { Camera, Plus, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Plus, AlertCircle, CheckCircle2 } from "lucide-react";
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 
@@ -80,15 +80,11 @@ export default function ArticlesPage() {
   return (
     <main className="min-h-screen w-full flex flex-col items-center p-5">
       <div className="w-full max-w-none flex-1 flex flex-col gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-2xl font-semibold">Articles</h1>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={openScanner} className="flex items-center gap-2">
-              <Camera className="w-4 h-4" />
-              Asset-Tag scannen
-            </Button>
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
             <Button asChild>
-              <Link href="/management/articles/new" className="flex items-center gap-2">
+              <Link href="/management/articles/new" className="flex items-center justify-center gap-2 sm:justify-start">
                 <Plus className="w-4 h-4" />
                 Neu
               </Link>
@@ -112,7 +108,7 @@ export default function ArticlesPage() {
           </div>
         )}
 
-        <ArticleTable pageSize={10} />
+  <ArticleTable pageSize={10} onScanClick={openScanner} />
       </div>
 
       {/* QR Scanner Modal */}

--- a/app/management/equipments/page.tsx
+++ b/app/management/equipments/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { QrScannerModal } from "@/components/camera/qr-scanner-modal";
 import { useQrScanner } from "@/components/camera/use-qr-scanner";
 import { createClient } from "@/lib/supabase/client";
-import { Camera, Plus, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Plus, AlertCircle, CheckCircle2 } from "lucide-react";
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 
@@ -78,17 +78,16 @@ export default function EquipmentsPage() {
   };
 
   return (
-    <main className="min-h-screen w-full flex flex-col items-center p-5">
+    <main className="min-h-screen w-full flex flex-col items-center px-3 py-4 sm:px-5 sm:py-6">
       <div className="w-full max-w-none flex-1 flex flex-col gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-2xl font-semibold">Equipments</h1>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={openScanner} className="flex items-center gap-2">
-              <Camera className="w-4 h-4" />
-              Asset-Tag scannen
-            </Button>
-            <Button asChild>
-              <Link href="/management/equipments/new" className="flex items-center gap-2">
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+            <Button asChild className="w-full sm:w-auto">
+              <Link
+                href="/management/equipments/new"
+                className="flex w-full items-center justify-center gap-2 sm:w-auto sm:justify-start"
+              >
                 <Plus className="w-4 h-4" />
                 Neu
               </Link>
@@ -112,7 +111,11 @@ export default function EquipmentsPage() {
           </div>
         )}
 
-        <EquipmentTable pageSize={10} />
+        <EquipmentTable
+          pageSize={10}
+          className="-mx-3 rounded-none border-x-0 sm:mx-0 sm:rounded-xl"
+          onScanClick={openScanner}
+        />
       </div>
 
       {/* QR Scanner Modal */}

--- a/app/management/locations/page.tsx
+++ b/app/management/locations/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { QrScannerModal } from "@/components/camera/qr-scanner-modal";
 import { useQrScanner } from "@/components/camera/use-qr-scanner";
 import { createClient } from "@/lib/supabase/client";
-import { Camera, Plus, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Plus, AlertCircle, CheckCircle2 } from "lucide-react";
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 
@@ -80,15 +80,11 @@ export default function LocationsPage() {
   return (
     <main className="min-h-screen w-full flex flex-col items-center p-5">
       <div className="w-full max-w-none flex-1 flex flex-col gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-2xl font-semibold">Standorte</h1>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={openScanner} className="flex items-center gap-2">
-              <Camera className="w-4 h-4" />
-              Asset-Tag scannen
-            </Button>
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
             <Button asChild>
-              <Link href="/management/locations/new" className="flex items-center gap-2">
+              <Link href="/management/locations/new" className="flex items-center justify-center gap-2 sm:justify-start">
                 <Plus className="w-4 h-4" />
                 Neu
               </Link>
@@ -112,7 +108,7 @@ export default function LocationsPage() {
           </div>
         )}
 
-        <LocationTable pageSize={10} />
+  <LocationTable pageSize={10} onScanClick={openScanner} />
       </div>
 
       {/* QR Scanner Modal */}

--- a/components/articleTable.tsx
+++ b/components/articleTable.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import type { Tables } from '@/database.types';
 import Link from 'next/link';
-import { Pencil } from 'lucide-react';
+import { Pencil, Scan } from 'lucide-react';
 import { DataTable } from '@/components/data-table';
 
 type Article = Tables<"articles">;
@@ -16,9 +16,10 @@ type ArticleRow = Article & {
 type Props = {
   pageSize?: number;
   className?: string;
+  onScanClick?: () => void;
 };
 
-export function ArticleTable({ pageSize = 10, className }: Props) {
+export function ArticleTable({ pageSize = 10, className, onScanClick }: Props) {
 
   const columns = [
     { key: 'id', label: 'ID', render: (row: ArticleRow) => <Link className="underline-offset-2 hover:underline" href={`/management/articles/${row.id}`}>{row.id}</Link> },
@@ -42,6 +43,25 @@ export function ArticleTable({ pageSize = 10, className }: Props) {
     </Button>
   );
 
+  const searchTrailingAction = onScanClick ? (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      onClick={onScanClick}
+      className="h-9 w-9"
+    >
+      <Scan className="h-4 w-4" />
+      <span className="sr-only">Asset-Tag scannen</span>
+    </Button>
+  ) : null;
+
+  const renderMobileFooterRight = (row: ArticleRow) => {
+    const assetTagCode = row.asset_tags?.printed_code ?? (row.asset_tag ? `#${row.asset_tag}` : null);
+    if (!assetTagCode) return null;
+    return `Asset-Tag ${assetTagCode}`;
+  };
+
   return (
     <DataTable<ArticleRow>
       tableName="articles"
@@ -49,6 +69,9 @@ export function ArticleTable({ pageSize = 10, className }: Props) {
       renderRowActions={renderRowActions}
       pageSize={pageSize}
       className={className}
+  searchTrailingAction={searchTrailingAction}
+      mobileHiddenColumnKeys={['asset_tag']}
+      renderMobileFooterRight={renderMobileFooterRight}
       searchableFields={[
         { field: 'id', type: 'number' },
         { field: 'name', type: 'text' },

--- a/components/customerTable.tsx
+++ b/components/customerTable.tsx
@@ -37,6 +37,11 @@ export function CustomerTable({ pageSize = 10, className }: Props) {
     </Button>
   );
 
+  const renderMobileFooterRight = (row: Contact) => {
+    if (!row.contact_type) return null;
+    return `Typ ${row.contact_type}`;
+  };
+
   return (
     <DataTable<Contact>
       tableName="contacts"
@@ -44,6 +49,7 @@ export function CustomerTable({ pageSize = 10, className }: Props) {
       renderRowActions={renderRowActions}
       pageSize={pageSize}
       className={className}
+      renderMobileFooterRight={renderMobileFooterRight}
       searchableFields={[
         { field: 'id', type: 'number' },
         { field: 'company_name', type: 'text' },

--- a/components/locationTable.tsx
+++ b/components/locationTable.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import type { Tables } from '@/database.types';
 import Link from 'next/link';
-import { Pencil } from 'lucide-react';
+import { Pencil, Scan } from 'lucide-react';
 import { DataTable } from '@/components/data-table';
 
 type LocationRow = Tables<"locations"> & { asset_tags?: { printed_code: string | null } | null };
@@ -11,9 +11,10 @@ type LocationRow = Tables<"locations"> & { asset_tags?: { printed_code: string |
 type Props = {
   pageSize?: number;
   className?: string;
+  onScanClick?: () => void;
 };
 
-export function LocationTable({ pageSize = 10, className }: Props) {
+export function LocationTable({ pageSize = 10, className, onScanClick }: Props) {
   const columns = [
     { key: 'id', label: 'ID', render: (row: LocationRow) => <Link className="underline-offset-2 hover:underline" href={`/management/locations/${row.id}`}>{row.id}</Link> },
     { key: 'name', label: 'Name', render: (row: LocationRow) => <Link className="underline-offset-2 hover:underline" href={`/management/locations/${row.id}`}>{row.name}</Link> },
@@ -27,6 +28,25 @@ export function LocationTable({ pageSize = 10, className }: Props) {
     </Button>
   );
 
+  const searchTrailingAction = onScanClick ? (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      onClick={onScanClick}
+      className="h-9 w-9"
+    >
+      <Scan className="h-4 w-4" />
+      <span className="sr-only">Asset-Tag scannen</span>
+    </Button>
+  ) : null;
+
+  const renderMobileFooterRight = (row: LocationRow) => {
+    const assetTagCode = row.asset_tags?.printed_code ?? (row.asset_tag ? `#${row.asset_tag}` : null);
+    if (!assetTagCode) return null;
+    return `Asset-Tag ${assetTagCode}`;
+  };
+
   return (
     <DataTable<LocationRow>
       tableName="locations"
@@ -34,6 +54,9 @@ export function LocationTable({ pageSize = 10, className }: Props) {
       renderRowActions={renderRowActions}
       pageSize={pageSize}
       className={className}
+      searchTrailingAction={searchTrailingAction}
+      mobileHiddenColumnKeys={['asset_tag']}
+      renderMobileFooterRight={renderMobileFooterRight}
       searchableFields={[
         { field: 'id', type: 'number' },
         { field: 'name', type: 'text' },

--- a/tests/e2e/equipment-list-responsive.loggedin.spec.ts
+++ b/tests/e2e/equipment-list-responsive.loggedin.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from '@playwright/test';
+import { test } from '../playwright_setup.types';
+
+test.describe('Equipment list responsive layout', () => {
+  test.describe('mobile view', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('renders stacked cards without horizontal scrolling', async ({ page }) => {
+      await page.goto('/management/equipments');
+      await page.waitForLoadState('networkidle');
+
+      const cards = page.locator('[data-testid="data-table-mobile-card"]');
+      await expect(cards.first()).toBeVisible();
+
+      const table = page.locator('table');
+      if (await table.count()) {
+        await expect(table.first()).toBeHidden();
+      }
+
+      const hasHorizontalScroll = await page.evaluate(() => {
+        const root = document.scrollingElement ?? document.documentElement;
+        const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+        if (!root) return false;
+        return root.scrollWidth > viewportWidth + 1;
+      });
+
+      expect(hasHorizontalScroll).toBeFalsy();
+    });
+  });
+
+  test.describe('desktop view', () => {
+    test.use({ viewport: { width: 1280, height: 800 } });
+
+    test('keeps table layout visible on larger screens', async ({ page }) => {
+      await page.goto('/management/equipments');
+      await page.waitForLoadState('networkidle');
+
+      const table = page.locator('table');
+      await expect(table.first()).toBeVisible();
+
+      const mobileList = page.locator('[data-testid="data-table-mobile"]');
+      if (await mobileList.count()) {
+        await expect(mobileList.first()).toBeHidden();
+      }
+    });
+  });
+});

--- a/todos.md
+++ b/todos.md
@@ -130,3 +130,4 @@ Diese To-Do List enthält Aufgaben, die an der Software zu bearbeiten sind. Soba
   - Abmelden (Supabase Sign-Out)
 
 - Fix: Article & Equipment Metadata Forms vollständig refactored für Case & Rack Setup. Radio-Button Modus-Auswahl (Keine/Case ist Rack/Equipment ist rackmontierbar) mit gegenseitig ausschließender Logik. "19-Zoll Rackmontage" aus Physical Card entfernt und in Case Setup integriert. Konditionale Felder je nach Modus mit visueller Border-Farb-Codierung (blau=Case, grün=Equipment). Physical Card zeigt jetzt nur noch Gewicht und Maße. Alle Rack-Konfigurationen in einer einzigen "Case & Rack Setup" Karte zusammengefasst.
+- [ ] Mobile equipment table padding fixes


### PR DESCRIPTION
This pull request introduces a major overhaul of the mobile and responsive layouts for the management tables (Equipment, Articles, Locations, and Contacts), focusing on improving usability and consistency across devices. The changes unify the search and scan experience, optimize table layouts for mobile, and introduce new footer behaviors for key information. Additionally, some workflow and caching steps have been streamlined.

**Mobile & Responsive Table Improvements**

* All management tables (`components/data-table.tsx`, `components/equipmentTable.tsx`, `components/articleTable.tsx`, `components/locationTable.tsx`, `components/customerTable.tsx`) now support mobile-optimized layouts: ID columns are hidden on mobile and shown in a left-aligned footer, while right footers display context-specific information (e.g., Asset-Tag, Contact Type). Rows are more compact, and fields are grouped for better readability on small screens. [[1]](diffhunk://#diff-5e864907c024930ab417ea9b442648e9979d7d9322d9d988a2ae5608bff75f29R46-R74) [[2]](diffhunk://#diff-eada8eae547553c487657e729541e70633962558086cc9321e3630ed7c20610eR40-R52) [[3]](diffhunk://#diff-953da6fd1817fc80f9e67712e49cf202f7157baea3656d8933d45a96676f56eeR22-R25) [[4]](diffhunk://#diff-953da6fd1817fc80f9e67712e49cf202f7157baea3656d8933d45a96676f56eeL33-R42) [[5]](diffhunk://#diff-bfa29b95d0b3125d494d6e236086aba7a1497981bd94e1bb465fcc2e2ec0cfbeR1-R52) [[6]](diffhunk://#diff-bfa29b95d0b3125d494d6e236086aba7a1497981bd94e1bb465fcc2e2ec0cfbeR1370-R1374)

* The search bar in Articles, Equipments, and Locations tables now features a scan icon button for quick Asset-Tag scanning, replacing the previous header button. The scan handler is passed directly to the table, improving code clarity and UX. [[1]](diffhunk://#diff-5e864907c024930ab417ea9b442648e9979d7d9322d9d988a2ae5608bff75f29R19-R22) [[2]](diffhunk://#diff-5e864907c024930ab417ea9b442648e9979d7d9322d9d988a2ae5608bff75f29R46-R74) [[3]](diffhunk://#diff-7d02de33aa8a3b68ab062175b34fbf61cf8eb90ec9d6cf21646fbf1c3e0a02b3L115-R111) [[4]](diffhunk://#diff-cbbbd22617e1e7e2075227b11075a8609e820a37578dd1cf1a7c861c5ddff186L115-R118) [[5]](diffhunk://#diff-163b0306ff789f9eb3776e02a146cf2c453ed97e1165a80b112cb7e6eb09e049L115-R111) [[6]](diffhunk://#diff-bfa29b95d0b3125d494d6e236086aba7a1497981bd94e1bb465fcc2e2ec0cfbeR1-R52)

* The Equipment overview card on small viewports is now flush with the screen edge (no horizontal margin or border radius), while the desktop version retains its padding and rounded corners. [[1]](diffhunk://#diff-cbbbd22617e1e7e2075227b11075a8609e820a37578dd1cf1a7c861c5ddff186L81-R90) [[2]](diffhunk://#diff-bfa29b95d0b3125d494d6e236086aba7a1497981bd94e1bb465fcc2e2ec0cfbeR1370-R1374)

**Component & API Enhancements**

* The generic `DataTable` component accepts new props for customizing mobile layouts: `searchTrailingAction`, `mobileHiddenColumnKeys`, `renderMobileFooterLeft`, and `renderMobileFooterRight`, allowing each table to define its own mobile footer content and search actions. [[1]](diffhunk://#diff-953da6fd1817fc80f9e67712e49cf202f7157baea3656d8933d45a96676f56eeR22-R25) [[2]](diffhunk://#diff-953da6fd1817fc80f9e67712e49cf202f7157baea3656d8933d45a96676f56eeL33-R42)

**UI Consistency & Cleanup**

* Removed unused `Camera` icon imports and old scan buttons from Articles, Equipments, and Locations page headers, centralizing the scan action in the table search bar for a cleaner, more consistent UI. [[1]](diffhunk://#diff-7d02de33aa8a3b68ab062175b34fbf61cf8eb90ec9d6cf21646fbf1c3e0a02b3L9-R9) [[2]](diffhunk://#diff-7d02de33aa8a3b68ab062175b34fbf61cf8eb90ec9d6cf21646fbf1c3e0a02b3L83-R87) [[3]](diffhunk://#diff-cbbbd22617e1e7e2075227b11075a8609e820a37578dd1cf1a7c861c5ddff186L9-R9) [[4]](diffhunk://#diff-cbbbd22617e1e7e2075227b11075a8609e820a37578dd1cf1a7c861c5ddff186L81-R90) [[5]](diffhunk://#diff-163b0306ff789f9eb3776e02a146cf2c453ed97e1165a80b112cb7e6eb09e049L9-R9) [[6]](diffhunk://#diff-163b0306ff789f9eb3776e02a146cf2c453ed97e1165a80b112cb7e6eb09e049L83-R87)

**Workflow & CI/CD**

* Playwright browser cache pre-warming steps were removed from the GitHub Actions workflow, simplifying the CI pipeline.

These changes collectively provide a much improved mobile experience, cleaner code, and more maintainable table components.